### PR TITLE
[codex] Remove exposed Google Maps key placeholder

### DIFF
--- a/src/modules/roncaspot/index.jsx
+++ b/src/modules/roncaspot/index.jsx
@@ -21,7 +21,7 @@ function ScriptLoader() {
     useScript("assets/js/owl.carousel.min.js");
     useScript("assets/js/wow.js");
     useScript("assets/js/fancybox/jquery.fancybox.pack.js");
-    //useScript("https://maps.googleapis.com/maps/api/js?key=AIzaSyBkdsK7PWcojsO-o_q2tmFOLBfPGL8k8Vg");
+    // Google Maps loading is intentionally disabled; configure keys outside source if needed.
     //useScript("assets/js/gmap3.js");
     useScript("assets/js/init.js");
     useScript("assets/js/script.js");


### PR DESCRIPTION
## Summary

- Replace a disabled Google Maps script example with a neutral note to keep keys out of source.
- Leave the public site content and runtime behavior unchanged.

## Validation

- `git diff --check`
- `npm run build --if-present` could not complete because this checkout is missing project dependencies (`craco` is not installed).

## Notes

This is part of the public repository internal-information cleanup pass.
